### PR TITLE
fix: dual webkit

### DIFF
--- a/androidcommon_lib/src/main/java/org/opendatakit/activities/IOdkDataActivity.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/activities/IOdkDataActivity.java
@@ -33,15 +33,17 @@ public interface IOdkDataActivity {
    * an optional parameter to identify which view should be signalled.
    *
    * @param responseJSON
+   * @param fragmentID
    */
-  void signalResponseAvailable(String responseJSON, String viewID);
+  void signalResponseAvailable(String responseJSON, String fragmentID);
 
   /**
    * Access the queued responseJSON
    *
+   * @param fragmentID
    * @return responseJSON or null if there is none available
    */
-  String getResponseJSON();
+  String getResponseJSON(String fragmentID);
 
   /**
    * Return a new ExecutorProcessor that will be able to process data off the

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorContext.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorContext.java
@@ -93,9 +93,10 @@ public class ExecutorContext implements DatabaseConnectionListener {
     }
 
     public static synchronized ExecutorContext getContext(IOdkDataActivity fragment) {
-      if ( currentContext != null && (currentContext.activity == fragment)) {
+      if ( currentContext != null && (currentContext.activity == fragment) && currentContext.isAlive()) {
         return currentContext;
       } else {
+        // the constructor will update currentContext...
         return new ExecutorContext(fragment);
       }
     }

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorProcessor.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorProcessor.java
@@ -185,7 +185,11 @@ public abstract class ExecutorProcessor implements Runnable {
     } catch (SQLiteException e) {
       reportErrorAndCleanUp(SQLiteException.class.getName() +
           ": " + e.getMessage());
+    } catch (IllegalStateException e) {
+      WebLogger.getLogger(context.getAppName()).printStackTrace(e);
+      reportErrorAndCleanUp(IllegalStateException.class.getName() + ": " + e.getMessage());
     } catch (Throwable t) {
+      WebLogger.getLogger(context.getAppName()).printStackTrace(t);
       reportErrorAndCleanUp(IllegalStateException.class.getName() +
           ": ExecutorProcessor unexpected exception " + t.toString());
     }
@@ -198,10 +202,12 @@ public abstract class ExecutorProcessor implements Runnable {
    */
   private void reportErrorAndCleanUp(String errorMessage) {
     try {
-      dbInterface.closeDatabase(context.getAppName(), dbHandle);
-    } catch (Exception e) {
+      if ( dbHandle != null ) {
+        dbInterface.closeDatabase(context.getAppName(), dbHandle);
+      }
+    } catch (Throwable t) {
       // ignore this -- favor first reported error
-      WebLogger.getLogger(context.getAppName()).printStackTrace(e);
+      WebLogger.getLogger(context.getAppName()).printStackTrace(t);
       WebLogger.getLogger(context.getAppName()).w(TAG, "error while releasing database conneciton");
     } finally {
       context.removeActiveConnection(transId);

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorRequest.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorRequest.java
@@ -15,6 +15,7 @@
 package org.opendatakit.views;
 
 import org.opendatakit.database.queries.BindArgs;
+import org.opendatakit.logging.WebLogger;
 
 /**
  * @author mitchellsundt@gmail.com
@@ -84,6 +85,7 @@ public class ExecutorRequest {
         this.deleteAllCheckpoints = false;
         this.commitTransaction = false;
         this.callerID = null;
+        WebLogger.getContextLogger().d("ExecutorRequest", "updateExecutorContext");
     }
 
     /**

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
@@ -17,6 +17,7 @@ package org.opendatakit.views;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.opendatakit.activities.IOdkDataActivity;
+import org.opendatakit.consts.IntentConsts;
 import org.opendatakit.database.queries.BindArgs;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.provider.DataTableColumns;
@@ -44,11 +45,11 @@ public class OdkData {
     /**
      * for conflict resolution screens
      */
-    public static final String TABLE_ID = "tableId";
+    public static final String TABLE_ID = IntentConsts.INTENT_KEY_TABLE_ID;
     /**
      * common for all activities
      */
-    public static final String APP_NAME = "appName";
+    public static final String APP_NAME = IntentConsts.INTENT_KEY_APP_NAME;
     /**
      * Tells what time of view it should be
      * displaying.
@@ -72,7 +73,7 @@ public class OdkData {
      */
     public static final String SQL_WHERE = "sqlWhereClause";
     /**
-     * An array of strings for restricting the rows displayed in the table.
+     * A JSON serialization of an array of objects for restricting the rows displayed in the table.
      */
     public static final String SQL_SELECTION_ARGS = "sqlSelectionArgs";
     /**

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
@@ -141,7 +141,7 @@ public class OdkData {
    * @return null if there is no result, otherwise the responseJSON of the last action
    */
   public String getResponseJSON() {
-    return mActivity.getResponseJSON();
+    return mActivity.getResponseJSON(getFragmentID());
   }
 
   /**
@@ -176,11 +176,13 @@ public class OdkData {
 
   private String getFragmentID() {
     IOdkWebView webView = mWebView.get();
-     if (webView == null) {
-        return null;
-     }
+    if (webView == null) {
+      // should not occur unless we are tearing down the view
+      WebLogger.getLogger(mActivity.getAppName()).w(TAG, "null webView");
+      return null;
+    }
 
-     return webView.getContainerFragmentID();
+    return webView.getContainerFragmentID();
   }
 
   /**

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ViewDataQueryParams.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ViewDataQueryParams.java
@@ -23,14 +23,14 @@ import org.opendatakit.database.queries.BindArgs;
  */
 
 public class ViewDataQueryParams implements Parcelable {
-   public String tableId;
-   public String rowId;
-   public String whereClause;
-   public BindArgs selectionArgs;
-   public String[] groupBy;
-   public String having;
-   public String orderByElemKey;
-   public String orderByDir;
+   public final String tableId;
+   public final String rowId;
+   public final String whereClause;
+   public final BindArgs selectionArgs;
+   public final String[] groupBy;
+   public final String having;
+   public final String orderByElemKey;
+   public final String orderByDir;
 
    public ViewDataQueryParams(String tableId, String rowId, String whereClause, BindArgs
        selectionArgs, String[] groupBy, String having, String orderByElemKey, String orderByDir) {


### PR DESCRIPTION
The odkData responses need to be separately queued for each webkit.
Logic error: if the current context is not alive, then we should create a new one.

Changes are required for tables and survey