### PR TITLE
url cleanup -- and removal of context argument

### DIFF
--- a/androidcommon_lib/src/androidTest/java/org/opendatakit/webkitserver/utilities/UrlUtilsTest.java
+++ b/androidcommon_lib/src/androidTest/java/org/opendatakit/webkitserver/utilities/UrlUtilsTest.java
@@ -15,7 +15,6 @@
 package org.opendatakit.webkitserver.utilities;
 
 import android.support.test.runner.AndroidJUnit4;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -111,7 +110,7 @@ public class UrlUtilsTest {
    * @param start
    */
   protected void assertRetrieveFileNameHelper(String expected, String start) {
-    String result = UrlUtils.getFileNameFromUriSegment(start);
+    String result = UrlUtils.getPathFromUriFragment(start);
     assertEquals(expected, result);
   }
   
@@ -121,7 +120,7 @@ public class UrlUtilsTest {
   }
   
   protected void assertGetParamsHelper(String segment, String expected) {
-    String actual = UrlUtils.getParametersFromSegment(segment);
+    String actual = UrlUtils.getParametersFromUriFragment(segment);
     assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
Change UrlUtils to not have a context argument (first argument). The argument into many of these methods should be a uriFragment consisting of everything from a well-formed URI after the appName plus optional query and hash parameters. Revise comments and naming accordingly. Change getAsWebViewUri() to reconstruct the full URI and assume that all escaping has already been done via the ODKFileUtils methods that convert file paths into uri fragments.

Dependent upon #https://github.com/opendatakit/androidlibrary/pull/29