### PR TITLE
Additional runtime permission checks

### DIFF
--- a/androidcommon_lib/src/main/res/values/strings.xml
+++ b/androidcommon_lib/src/main/res/values/strings.xml
@@ -28,5 +28,6 @@
 
     <string name="required_permission_rationale">This app needs external storage access to interact with other ODK apps</string>
     <string name="required_permission_perm_denied">This app cannot function without write access to external storage</string>
+    <string name="required_permission_perm_denied_services">Services cannot function without write access to external storage</string>
 
 </resources>


### PR DESCRIPTION
Let `BaseLauncherActivity` launch Services to get permissions. 

Depends on https://github.com/opendatakit/androidlibrary/pull/30