### PR TITLE
Check dependencies before checking permissions

### DIFF
--- a/androidcommon_lib/src/main/java/org/opendatakit/activities/BaseLauncherActivity.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/activities/BaseLauncherActivity.java
@@ -15,6 +15,7 @@ import android.widget.Toast;
 import org.opendatakit.androidcommon.R;
 import org.opendatakit.consts.IntentConsts;
 import org.opendatakit.consts.RequestCodeConsts;
+import org.opendatakit.dependencies.DependencyChecker;
 import org.opendatakit.utilities.RuntimePermissionUtils;
 
 
@@ -33,6 +34,10 @@ public abstract class BaseLauncherActivity extends BaseActivity implements Activ
     super.onCreate(savedInstanceState);
 
     this.savedInstanceState = savedInstanceState;
+
+    if (!DependencyChecker.checkDependencies(this)) {
+      return;
+    }
 
     // 1. check if Services has the right permissions
     //      if not, launch Services


### PR DESCRIPTION
To prevent a crash when Services is not installed. 