### PR TITLE
metadata cache propagated to JS layer

### DIFF
--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorProcessor.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorProcessor.java
@@ -18,10 +18,8 @@ import android.content.ContentValues;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.opendatakit.aggregate.odktables.rest.ElementDataType;
-import org.opendatakit.database.data.ColumnDefinition;
-import org.opendatakit.database.data.OrderedColumns;
-import org.opendatakit.database.data.TableDefinitionEntry;
-import org.opendatakit.database.data.UserTable;
+import org.opendatakit.aggregate.odktables.rest.KeyValueStoreConstants;
+import org.opendatakit.database.data.*;
 import org.opendatakit.exception.ActionNotAuthorizedException;
 import org.opendatakit.exception.ServicesAvailabilityException;
 import org.opendatakit.provider.DataTableColumns;
@@ -30,10 +28,7 @@ import org.opendatakit.utilities.DataHelper;
 import org.opendatakit.utilities.ODKFileUtils;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.database.service.UserDbInterface;
-import org.opendatakit.database.data.KeyValueStoreEntry;
 import org.opendatakit.database.service.DbHandle;
-import org.opendatakit.database.data.Row;
-import org.opendatakit.database.data.BaseTable;
 import org.opendatakit.database.queries.ResumableQuery;
 import org.sqlite.database.sqlite.SQLiteException;
 
@@ -367,9 +362,10 @@ public abstract class ExecutorProcessor implements Runnable {
   }
 
   private void populateKeyValueStoreList(Map<String, Object> metadata,
-      List<KeyValueStoreEntry> entries) {
+      List<KeyValueStoreEntry> entries) throws ServicesAvailabilityException {
     // keyValueStoreList
     if (entries != null) {
+      Map<String,String> choiceMap = new HashMap<String,String>();
       // It is unclear how to most easily represent the KVS for access.
       // We use the convention in ODK Survey, which is a list of maps,
       // one per KVS row, with integer, number and boolean resolved to JS
@@ -426,22 +422,28 @@ public abstract class ExecutorProcessor implements Runnable {
         anEntry.put("value", value);
 
         kvsArray.add(anEntry);
+
+        // and resolve the choice values
+        // this may explode the size of the KVS going back to the JS layer.
+        if ( entry.partition.equals(KeyValueStoreConstants.PARTITION_COLUMN) &&
+            entry.key.equals(KeyValueStoreConstants.COLUMN_DISPLAY_CHOICES_LIST) &&
+            !choiceMap.containsKey(entry.value)) {
+          String choiceList = dbInterface.getChoiceList(context.getAppName(), dbHandle, entry.value);
+          choiceMap.put(entry.value, choiceList);
+        }
       }
       metadata.put("keyValueStoreList", kvsArray);
+      metadata.put("choiceListMap", choiceMap);
     }
   }
 
   private void reportArbitraryQuerySuccessAndCleanUp(OrderedColumns columnDefinitions,
       BaseTable userTable) throws ServicesAvailabilityException {
-    List<KeyValueStoreEntry> entries = null;
 
-    // We are assuming that we always have the KVS
-    // otherwise use the request.includeKeyValueStoreMap
-    //if (request.includeKeyValueStoreMap) {
-    entries = dbInterface
+    TableMetaDataEntries metaDataEntries =
+       dbInterface
         .getTableMetadata(context.getAppName(), dbHandle, request.tableId, null, null, null,
-            userTable.getMetaDataRev()).getEntries();
-    //}
+            null);
     TableDefinitionEntry tdef = dbInterface
         .getTableDefinitionEntry(context.getAppName(), dbHandle, request.tableId);
 
@@ -507,11 +509,22 @@ public abstract class ExecutorProcessor implements Runnable {
 
     // elementKey -> index in row within row list
     metadata.put("elementKeyMap", elementKeyToIndexMap);
-    // dataTableModel -- JS nested schema struct { elementName : extended_JS_schema_struct, ...}
-    TreeMap<String, Object> dataTableModel = columnDefinitions.getExtendedDataModel();
-    metadata.put("dataTableModel", dataTableModel);
-    // keyValueStoreList
-    populateKeyValueStoreList(metadata, entries);
+
+    // include metadata only if requested and if the existing metadata version is out-of-date.
+    if ( request.tableId != null && request.includeFullMetadata &&
+            (request.metaDataRev == null ||
+             !request.metaDataRev.equals(metaDataEntries.getRevId())) ) {
+
+      Map<String, Object> cachedMetadata = new HashMap<String, Object>();
+
+      cachedMetadata.put("metaDataRev", metaDataEntries.getRevId());
+      // dataTableModel -- JS nested schema struct { elementName : extended_JS_schema_struct, ...}
+      TreeMap<String, Object> dataTableModel = columnDefinitions.getExtendedDataModel();
+      cachedMetadata.put("dataTableModel", dataTableModel);
+      // keyValueStoreList
+      populateKeyValueStoreList(cachedMetadata, metaDataEntries.getEntries());
+      metadata.put("cachedMetadata", cachedMetadata);
+    }
 
     // raw queries are not extended.
     reportSuccessAndCleanUp(data, metadata);
@@ -604,15 +617,11 @@ public abstract class ExecutorProcessor implements Runnable {
   }
 
   private void reportSuccessAndCleanUp(UserTable userTable) throws ServicesAvailabilityException {
-    List<KeyValueStoreEntry> entries = null;
+    TableMetaDataEntries metaDataEntries =
+        dbInterface
+            .getTableMetadata(context.getAppName(), dbHandle, request.tableId, null, null, null,
+                null);
 
-    // We are assuming that we always have the KVS
-    // otherwise use the request.includeKeyValueStoreMap
-    //if (request.includeKeyValueStoreMap) {
-    entries = dbInterface
-        .getTableMetadata(context.getAppName(), dbHandle, request.tableId, null, null, null,
-            userTable.getMetaDataRev()).getEntries();
-    //}
     TableDefinitionEntry tdef = dbInterface
         .getTableDefinitionEntry(context.getAppName(), dbHandle, request.tableId);
 
@@ -673,15 +682,33 @@ public abstract class ExecutorProcessor implements Runnable {
 
     // elementKey -> index in row within row list
     metadata.put("elementKeyMap", elementKeyToIndexMap);
-    // dataTableModel -- JS nested schema struct { elementName : extended_JS_schema_struct, ...}
-    TreeMap<String, Object> dataTableModel = columnDefinitions.getExtendedDataModel();
-    metadata.put("dataTableModel", dataTableModel);
-    // keyValueStoreList
-    populateKeyValueStoreList(metadata, entries);
 
-    // extend the metadata with whatever else this app needs....
-    // e.g., row and column color maps
-    extendQueryMetadata(dbInterface, dbHandle, entries, userTable, metadata);
+    // include metadata only if requested and if the existing metadata version is out-of-date.
+    if ( request.tableId != null && request.includeFullMetadata &&
+        (request.metaDataRev == null ||
+            !request.metaDataRev.equals(metaDataEntries.getRevId())) ) {
+
+      Map<String, Object> cachedMetadata = new HashMap<String, Object>();
+
+      cachedMetadata.put("metaDataRev", metaDataEntries.getRevId());
+      // dataTableModel -- JS nested schema struct { elementName : extended_JS_schema_struct, ...}
+      TreeMap<String, Object> dataTableModel = columnDefinitions.getExtendedDataModel();
+      cachedMetadata.put("dataTableModel", dataTableModel);
+      // keyValueStoreList
+      populateKeyValueStoreList(cachedMetadata, metaDataEntries.getEntries());
+      metadata.put("cachedMetadata", cachedMetadata);
+    }
+
+    // Always include tool-specific metadata if we are including metadata.
+    // The tool-specific metadata, such as cell, row, status and column colors
+    // varies with the content of the individual rows and therefore must always
+    // be returned.
+    if ( request.includeFullMetadata ) {
+      // extend the metadata with whatever else this app needs....
+      // e.g., row and column color maps
+      extendQueryMetadata(dbInterface, dbHandle, metaDataEntries.getEntries(), userTable, metadata);
+    }
+
     reportSuccessAndCleanUp(data, metadata);
   }
 

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorRequest.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/ExecutorRequest.java
@@ -45,7 +45,7 @@ public class ExecutorRequest {
     public final String orderByDirection;
     public final Integer limit;
     public final Integer offset;
-    public final boolean includeKeyValueStoreMap;
+    public final boolean includeFullMetadata;
 
     // For user table modification interactions
     public final String stringifiedJSON;
@@ -56,6 +56,9 @@ public class ExecutorRequest {
 
     // For commit interaction
     public final boolean commitTransaction;
+
+    // For tableId interactions
+    public final String metaDataRev;
 
     // For most interactions
     public final String callbackJSON;
@@ -70,6 +73,7 @@ public class ExecutorRequest {
         // unused:
         this.sqlCommand = null;
         this.sqlBindParams = null;
+        this.metaDataRev = null;
         this.callbackJSON = null;
         this.tableId = null;
         this.whereClause = null;
@@ -79,7 +83,7 @@ public class ExecutorRequest {
         this.orderByDirection = null;
         this.limit = null;
         this.offset = null;
-        this.includeKeyValueStoreMap = false;
+        this.includeFullMetadata = false;
         this.stringifiedJSON = null;
         this.rowId = null;
         this.deleteAllCheckpoints = false;
@@ -104,13 +108,16 @@ public class ExecutorRequest {
      *                     that can process the response
      */
     public ExecutorRequest(String tableId, String sqlCommand, BindArgs sqlBindParams,
-                Integer limit, Integer offset, String callbackJSON, String callerID) {
+                Integer limit, Integer offset, String metaDataRev, String callbackJSON,
+                           String callerID) {
         this.executorRequestType = ExecutorRequestType.ARBITRARY_QUERY;
         this.tableId = tableId;
         this.sqlCommand = sqlCommand;
         this.sqlBindParams = sqlBindParams;
         this.limit = limit;
         this.offset = offset;
+        this.metaDataRev = metaDataRev;
+        this.includeFullMetadata = (tableId != null);
         this.callbackJSON = callbackJSON;
         this.callerID = callerID;
 
@@ -121,7 +128,6 @@ public class ExecutorRequest {
         this.having = null;
         this.orderByElementKey = null;
         this.orderByDirection = null;
-        this.includeKeyValueStoreMap = false;
         this.stringifiedJSON = null;
         this.rowId = null;
         this.deleteAllCheckpoints = false;
@@ -141,14 +147,15 @@ public class ExecutorRequest {
      * @param orderByDirection 'ASC' or 'DESC' ordering
      * @param limit null to return everything. Otherwise, max number or rows to return
      * @param offset if limit is not null, specify the offset into the result set to return.
-     * @param includeKeyValueStoreMap true if the keyValueStoreMap should be returned
+     * @param includeFullMetadata true if the dataTableModel, KVS and extended (tool-specific)
+     *                            metadata should be returned
      * @param callbackJSON The JSON object used by the JS layer to recover the callback function
      *                     that can process the response
      */
     public ExecutorRequest(String tableId, String whereClause, BindArgs sqlBindParams,
                            String[] groupBy, String having, String orderByElementKey, String orderByDirection,
-                           Integer limit, Integer offset, boolean includeKeyValueStoreMap,
-                           String callbackJSON, String callerID) {
+                           Integer limit, Integer offset, boolean includeFullMetadata,
+                           String metaDataRev, String callbackJSON, String callerID) {
         this.executorRequestType = ExecutorRequestType.USER_TABLE_QUERY;
         this. tableId = tableId;
         this.whereClause = whereClause;
@@ -159,7 +166,8 @@ public class ExecutorRequest {
         this.orderByDirection = orderByDirection;
         this.limit = limit;
         this.offset = offset;
-        this.includeKeyValueStoreMap = includeKeyValueStoreMap;
+        this.includeFullMetadata = includeFullMetadata;
+        this.metaDataRev = metaDataRev;
         this.callbackJSON = callbackJSON;
         this.callerID = callerID;
 
@@ -194,11 +202,13 @@ public class ExecutorRequest {
      *                     that can process the response
      */
     public ExecutorRequest(ExecutorRequestType executorRequestType, String tableId, String stringifiedJSON, String rowId,
-        String callbackJSON, String callerID) {
+        String metaDataRev, String callbackJSON, String callerID) {
         this.executorRequestType = executorRequestType;
         this.tableId = tableId;
         this.stringifiedJSON = stringifiedJSON;
         this.rowId = rowId;
+        this.metaDataRev = metaDataRev;
+        this.includeFullMetadata = true;
         this.callbackJSON = callbackJSON;
         this.callerID = callerID;
 
@@ -213,7 +223,6 @@ public class ExecutorRequest {
         this.orderByDirection = null;
         this.limit = null;
         this.offset = null;
-        this.includeKeyValueStoreMap = false;
         this.deleteAllCheckpoints = false;
         this.commitTransaction = false;
     }
@@ -224,6 +233,7 @@ public class ExecutorRequest {
         this.tableId = null;
         this.stringifiedJSON = null;
         this.rowId = null;
+        this.metaDataRev = null;
         this.callbackJSON = callbackJSON;
         this.callerID = callerID;
 
@@ -238,7 +248,7 @@ public class ExecutorRequest {
         this.orderByDirection = null;
         this.limit = null;
         this.offset = null;
-        this.includeKeyValueStoreMap = false;
+        this.includeFullMetadata = false;
         this.deleteAllCheckpoints = false;
         this.commitTransaction = false;
     }

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkCommon.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkCommon.java
@@ -74,7 +74,8 @@ public class OdkCommon {
   }
 
   public boolean isInactive() {
-    return (mWebView.get() == null || mWebView.get().isInactive());
+    ODKWebView view = mWebView.get();
+    return (view == null || view.isInactive());
   }
 
   private void logDebug(String loggingString) {
@@ -284,6 +285,14 @@ public class OdkCommon {
   public String getSessionVariable(String elementPath) {
     logDebug("getSessionVariable("+elementPath+")");
     return mActivity.getSessionVariable(elementPath);
+  }
+
+  public void frameworkHasLoaded() {
+    logDebug("frameworkHasLoaded()");
+    ODKWebView view = mWebView.get();
+    if ( view != null ) {
+     view.frameworkHasLoaded();
+    }
   }
 
   /**

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkCommonIf.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkCommonIf.java
@@ -169,6 +169,24 @@ public class OdkCommonIf {
   }
 
   /**
+   * This is called within odkCommon.registerListener(fn) to indicate to the Java
+   * layer that a listener for doAction responses has been registered. Only after
+   * this has been invoked will doAction responses arriving after this cause a
+   * callback to be invoked on the Javascript side to trigger that listener.
+   *
+   * Prior to that, the doAction responses are silently queued in the Java layer
+   * awaiting their retrieval. The Javascript layer should call
+   * odkCommon.viewFirstQueuedAction() to retrieve any queued actions after having
+   * called odkCommon.registerListener(fn) to ensure that all actions are processed.
+   */
+  @android.webkit.JavascriptInterface
+  public void frameworkHasLoaded() {
+    if (isInactive())
+      return;
+    weakControl.get().frameworkHasLoaded();
+  }
+
+  /**
    * Execute an action (intent call).
    *
    * @param dispatchStructAsJSONstring Opaque string -- typically identifies prompt and user action

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkData.java
@@ -164,12 +164,12 @@ public class OdkData {
       BindArgs bindArgs = new BindArgs(new Object[] { queryParams.rowId });
       request = new ExecutorRequest(queryParams.tableId, DataTableColumns.ID + "=?", bindArgs,
           null, null, DataTableColumns.SAVEPOINT_TIMESTAMP, descOrder, limit, offset, true,
-          callbackJSON, getFragmentID());
+          null, callbackJSON, getFragmentID());
     } else {
       request = new ExecutorRequest(queryParams.tableId, queryParams.whereClause,
           queryParams.selectionArgs,
           queryParams.groupBy, queryParams.having, queryParams.orderByElemKey,
-          queryParams.orderByDir, limit, offset, true, callbackJSON, getFragmentID());
+          queryParams.orderByDir, limit, offset, true, null, callbackJSON, getFragmentID());
     }
     queueRequest(request);
   }
@@ -256,12 +256,12 @@ public class OdkData {
    */
   public void query(String tableId, String whereClause, String sqlBindParamsJSON, String[] groupBy,
       String having, String orderByElementKey, String orderByDirection,
-      Integer limit, Integer offset, boolean includeKeyValueStoreMap, String callbackJSON) {
+      Integer limit, Integer offset, boolean includeKeyValueStoreMap, String metaDataRev, String callbackJSON) {
     logDebug("query: " + tableId + " whereClause: " + whereClause);
     BindArgs bindArgs = new BindArgs(sqlBindParamsJSON);
     ExecutorRequest request = new ExecutorRequest(tableId, whereClause, bindArgs, groupBy,
         having, orderByElementKey, orderByDirection, limit, offset, includeKeyValueStoreMap,
-        callbackJSON, getFragmentID());
+        metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -284,11 +284,11 @@ public class OdkData {
    * @return see description in class header
    */
   public void arbitraryQuery(String tableId, String sqlCommand, String sqlBindParamsJSON,
-      Integer limit, Integer offset, String callbackJSON) {
+      Integer limit, Integer offset, String metaDataRev, String callbackJSON) {
     logDebug("arbitraryQuery: " + tableId + " sqlCommand: " + sqlCommand);
     BindArgs bindArgs = new BindArgs(sqlBindParamsJSON);
     ExecutorRequest request = new ExecutorRequest(tableId, sqlCommand, bindArgs,
-        limit, offset, callbackJSON, getFragmentID());
+        limit, offset, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -303,10 +303,10 @@ public class OdkData {
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
-  public void getRows(String tableId, String rowId, String callbackJSON) {
+  public void getRows(String tableId, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("getRows: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType.USER_TABLE_GET_ROWS, tableId,
-        null, rowId, callbackJSON, getFragmentID());
+        null, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -321,10 +321,10 @@ public class OdkData {
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
-  public void getMostRecentRow(String tableId, String rowId, String callbackJSON) {
+  public void getMostRecentRow(String tableId, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("getMostRecentRow: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(
-        ExecutorRequestType.USER_TABLE_GET_MOST_RECENT_ROW, tableId, null, rowId, callbackJSON,
+        ExecutorRequestType.USER_TABLE_GET_MOST_RECENT_ROW, tableId, null, rowId, metaDataRev, callbackJSON,
         getFragmentID());
 
     queueRequest(request);
@@ -340,11 +340,11 @@ public class OdkData {
    *                        that can process the response
    * @return see description in class header
    */
-  public void updateRow(String tableId, String stringifiedJSON, String rowId, String
-      callbackJSON) {
+  public void updateRow(String tableId, String stringifiedJSON, String rowId,
+                        String metaDataRev, String callbackJSON) {
     logDebug("updateRow: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType.USER_TABLE_UPDATE_ROW,
-        tableId, stringifiedJSON, rowId, callbackJSON, getFragmentID());
+        tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -360,7 +360,7 @@ public class OdkData {
     */
   public void changeAccessFilterOfRow(String tableId, String defaultAccess, String
       owner, String groupReadOnly, String groupModify, String groupPrivileged, String
-      rowId, String callbackJSON) {
+      rowId, String metaDataRev, String callbackJSON) {
 
     logDebug("changeAccessFilter: " + tableId + " _id: " + rowId);
     HashMap<String,String> valueMap = new HashMap<String,String>();
@@ -379,7 +379,7 @@ public class OdkData {
     }
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType
         .USER_TABLE_CHANGE_ACCESS_FILTER_ROW,
-        tableId, stringifiedJSON, rowId, callbackJSON, getFragmentID());
+        tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
 
@@ -393,10 +393,10 @@ public class OdkData {
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
-  public void deleteRow(String tableId, String stringifiedJSON, String rowId, String callbackJSON) {
+  public void deleteRow(String tableId, String stringifiedJSON, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("deleteRow: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType.USER_TABLE_DELETE_ROW,
-        tableId, stringifiedJSON, rowId, callbackJSON, getFragmentID());
+        tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -410,10 +410,10 @@ public class OdkData {
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
-  public void addRow(String tableId, String stringifiedJSON, String rowId, String callbackJSON) {
+  public void addRow(String tableId, String stringifiedJSON, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("addRow: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType.USER_TABLE_ADD_ROW, tableId,
-        stringifiedJSON, rowId, callbackJSON, getFragmentID());
+        stringifiedJSON, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -428,10 +428,10 @@ public class OdkData {
    *                        that can process the response
    */
   public void addCheckpoint(String tableId, String stringifiedJSON, String rowId,
-      String callbackJSON) {
+                            String metaDataRev, String callbackJSON) {
     logDebug("addCheckpoint: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(ExecutorRequestType.USER_TABLE_ADD_CHECKPOINT,
-        tableId, stringifiedJSON, rowId, callbackJSON, getFragmentID());
+        tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -446,11 +446,11 @@ public class OdkData {
    *                        that can process the response
    */
   public void saveCheckpointAsIncomplete(String tableId, String stringifiedJSON, String rowId,
-      String callbackJSON) {
+                                         String metaDataRev, String callbackJSON) {
     logDebug("saveCheckpointAsIncomplete: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(
         ExecutorRequestType.USER_TABLE_SAVE_CHECKPOINT_AS_INCOMPLETE, tableId, stringifiedJSON,
-        rowId, callbackJSON, getFragmentID());
+        rowId, metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -465,11 +465,11 @@ public class OdkData {
    *                        that can process the response
    */
   public void saveCheckpointAsComplete(String tableId, String stringifiedJSON, String rowId,
-      String callbackJSON) {
+                                       String metaDataRev, String callbackJSON) {
     logDebug("saveCheckpointAsComplete: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(
         ExecutorRequestType.USER_TABLE_SAVE_CHECKPOINT_AS_COMPLETE, tableId, stringifiedJSON, rowId,
-        callbackJSON, getFragmentID());
+        metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -482,11 +482,11 @@ public class OdkData {
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
-  public void deleteAllCheckpoints(String tableId, String rowId, String callbackJSON) {
+  public void deleteAllCheckpoints(String tableId, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("deleteAllCheckpoints: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(
         ExecutorRequestType.USER_TABLE_DELETE_ALL_CHECKPOINTS, tableId, null, rowId,
-        callbackJSON, getFragmentID());
+        metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }
@@ -499,11 +499,11 @@ public class OdkData {
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
-  public void deleteLastCheckpoint(String tableId, String rowId, String callbackJSON) {
+  public void deleteLastCheckpoint(String tableId, String rowId, String metaDataRev, String callbackJSON) {
     logDebug("deleteLastCheckpoint: " + tableId + " _id: " + rowId);
     ExecutorRequest request = new ExecutorRequest(
         ExecutorRequestType.USER_TABLE_DELETE_LAST_CHECKPOINT, tableId, null, rowId,
-        callbackJSON, getFragmentID());
+        metaDataRev, callbackJSON, getFragmentID());
 
     queueRequest(request);
   }

--- a/androidcommon_lib/src/main/java/org/opendatakit/views/OdkDataIf.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/views/OdkDataIf.java
@@ -259,13 +259,14 @@ public class OdkDataIf {
    * @param limit   The maximum number of rows to return (null for unlimited)
    * @param offset  The offset into the result set for the first row to return (null ok)
    * @param includeKeyValueStoreMap true if the keyValueStoreMap should be returned
+   * @param metaDataRev             The revision number of the metadata for this tableId, if known
    * @param callbackJSON            The JSON object used by the JS layer to recover the callback function
    *                                that can process the response
    */
   @android.webkit.JavascriptInterface public void query(String tableId, String whereClause,
       String sqlBindParamsJSON, String[] groupBy, String having, String orderByElementKey,
       String orderByDirection, String limit, String offset, boolean includeKeyValueStoreMap,
-      String callbackJSON)
+      String metaDataRev, String callbackJSON)
       {
     if (isInactive())
       return;
@@ -274,7 +275,7 @@ public class OdkDataIf {
     Integer integerOffset = (offset != null ? Integer.valueOf(offset) : null);
 
     weakData.get().query(tableId, whereClause, sqlBindParamsJSON, groupBy, having, orderByElementKey,
-        orderByDirection, integerLimit, integerOffset, includeKeyValueStoreMap, callbackJSON);
+        orderByDirection, integerLimit, integerOffset, includeKeyValueStoreMap, metaDataRev, callbackJSON);
   }
 
   /**
@@ -289,17 +290,18 @@ public class OdkDataIf {
    *                          the having clause)
    * @param limit   The maximum number of rows to return (null for unlimited)
    * @param offset  The offset into the result set for the first row to return (null ok)
+   * @param metaDataRev             The revision number of the metadata for this tableId, if known
    * @param callbackJSON  The JSON object used by the JS layer to recover the callback function
    *                      that can process the response
    */
   @android.webkit.JavascriptInterface public void arbitraryQuery(String tableId, String sqlCommand,
-      String sqlBindParamsJSON, String limit, String offset, String callbackJSON) {
+      String sqlBindParamsJSON, String limit, String offset, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
     Integer integerLimit = limit != null ? Integer.valueOf(limit) : null;
     Integer integerOffset = offset != null ? Integer.valueOf(offset) : null;
 
-    weakData.get().arbitraryQuery(tableId, sqlCommand, sqlBindParamsJSON, integerLimit, integerOffset, callbackJSON);
+    weakData.get().arbitraryQuery(tableId, sqlCommand, sqlBindParamsJSON, integerLimit, integerOffset, metaDataRev, callbackJSON);
   }
 
   /**
@@ -309,14 +311,15 @@ public class OdkDataIf {
    *
    * @param tableId      The table being updated
    * @param rowId        The rowId of the row being changed.
+   * @param metaDataRev  The revision number of the metadata for this tableId, if known
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
   @android.webkit.JavascriptInterface public void getRows(String tableId, String rowId,
-      String callbackJSON) {
+      String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().getRows(tableId, rowId, callbackJSON);
+    weakData.get().getRows(tableId, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -325,14 +328,15 @@ public class OdkDataIf {
    *
    * @param tableId      The table being updated
    * @param rowId        The rowId of the row being changed.
+   * @param metaDataRev  The revision number of the metadata for this tableId, if known
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
   @android.webkit.JavascriptInterface public void getMostRecentRow(String tableId, String rowId,
-      String callbackJSON) {
+      String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().getMostRecentRow(tableId, rowId, callbackJSON);
+    weakData.get().getMostRecentRow(tableId, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -341,33 +345,39 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being changed.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void updateRow(String tableId, String stringifiedJSON,
-      String rowId, String callbackJSON) {
+      String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().updateRow(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().updateRow(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
    * Update a row in the table with the given filter type and value.
    *
    * @param tableId         The table being updated
-   * @param defaultAccess      cannot be null. One of DEFAULT, MODIFY, READ_ONLY, HIDDEN
-   * @param owner     can be null. userid of owner of the row.
+   * @param defaultAccess   cannot be null. One of DEFAULT, MODIFY, READ_ONLY, HIDDEN
+   * @param owner           can be null. userid of owner of the row.
+   * @param groupReadOnly   can be null. Group name with read-only privileges.
+   * @param groupModify   can be null. Group name with read-write privileges.
+   * @param groupPrivileged   can be null. Group name with read-write-delete-alter-privilege
+   *                          privileges.
    * @param rowId           The rowId of the row being changed.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void changeAccessFilterOfRow(String tableId,
       String defaultAccess, String owner, String groupReadOnly, String groupModify, String groupPrivileged,
-      String rowId, String callbackJSON) {
+      String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
     weakData.get().changeAccessFilterOfRow(tableId, defaultAccess, owner, groupReadOnly, groupModify,
-            groupPrivileged, rowId, callbackJSON);
+            groupPrivileged, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -376,14 +386,15 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being deleted.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void deleteRow(String tableId, String stringifiedJSON,
-      String rowId, String callbackJSON) {
+      String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().deleteRow(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().deleteRow(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -392,14 +403,15 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being added.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void addRow(String tableId, String stringifiedJSON,
-      String rowId, String callbackJSON) {
+      String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().addRow(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().addRow(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -408,14 +420,15 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being added.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void addCheckpoint(String tableId,
-      String stringifiedJSON, String rowId, String callbackJSON) {
+      String stringifiedJSON, String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().addCheckpoint(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().addCheckpoint(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -424,14 +437,15 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being saved-as-incomplete.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void saveCheckpointAsIncomplete(String tableId,
-      String stringifiedJSON, String rowId, String callbackJSON) {
+      String stringifiedJSON, String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().saveCheckpointAsIncomplete(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().saveCheckpointAsIncomplete(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -440,14 +454,15 @@ public class OdkDataIf {
    * @param tableId         The table being updated
    * @param stringifiedJSON key-value map of values to store or update. If missing, the value remains unchanged.
    * @param rowId           The rowId of the row being marked-as-complete.
+   * @param metaDataRev     The revision number of the metadata for this tableId, if known
    * @param callbackJSON    The JSON object used by the JS layer to recover the callback function
    *                        that can process the response
    */
   @android.webkit.JavascriptInterface public void saveCheckpointAsComplete(String tableId,
-      String stringifiedJSON, String rowId, String callbackJSON) {
+      String stringifiedJSON, String rowId, String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().saveCheckpointAsComplete(tableId, stringifiedJSON, rowId, callbackJSON);
+    weakData.get().saveCheckpointAsComplete(tableId, stringifiedJSON, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -455,14 +470,15 @@ public class OdkDataIf {
    *
    * @param tableId      The table being updated
    * @param rowId        The rowId of the row being saved-as-incomplete.
+   * @param metaDataRev  The revision number of the metadata for this tableId, if known
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
   @android.webkit.JavascriptInterface public void deleteAllCheckpoints(String tableId, String rowId,
-      String callbackJSON) {
+      String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().deleteAllCheckpoints(tableId, rowId, callbackJSON);
+    weakData.get().deleteAllCheckpoints(tableId, rowId, metaDataRev, callbackJSON);
   }
 
   /**
@@ -470,13 +486,14 @@ public class OdkDataIf {
    *
    * @param tableId      The table being updated
    * @param rowId        The rowId of the row being saved-as-incomplete.
+   * @param metaDataRev  The revision number of the metadata for this tableId, if known
    * @param callbackJSON The JSON object used by the JS layer to recover the callback function
    *                     that can process the response
    */
   @android.webkit.JavascriptInterface public void deleteLastCheckpoint(String tableId, String rowId,
-      String callbackJSON) {
+      String metaDataRev, String callbackJSON) {
     if (isInactive())
       return;
-    weakData.get().deleteLastCheckpoint(tableId, rowId, callbackJSON);
+    weakData.get().deleteLastCheckpoint(tableId, rowId, metaDataRev, callbackJSON);
   }
 }


### PR DESCRIPTION
1. Pass metaDataRev down through the odkData interface and through the ExecutorRequest.

2. ExecutorProcessor fetches choice list definitions and passes them back in a 'choiceListMap' field. The metadata that can be cached on the JS side is returned in 'metadata.cachedMetadata'