### PR TITLE
Replace support-v13 ActivityCompat with support-v4 ActivityCompat

### DIFF
--- a/androidcommon_lib/build.gradle
+++ b/androidcommon_lib/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     api fileTree(include: '*.jar', dir: 'libs')
     api 'com.android.support:support-annotations:27.1.0'
     api 'com.android.support:support-v13:27.1.0'
+    api 'com.android.support:support-v4:27.1.0'
 
     if (libraryProjectPath.exists() && gradle.useLocal) { // Local project is favoured
         implementation project(libraryProjectName)

--- a/androidcommon_lib/src/main/java/org/opendatakit/activities/BaseLauncherActivity.java
+++ b/androidcommon_lib/src/main/java/org/opendatakit/activities/BaseLauncherActivity.java
@@ -9,7 +9,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v13.app.ActivityCompat;
+import android.support.v4.app.ActivityCompat;
 import android.widget.Toast;
 import org.opendatakit.androidcommon.R;
 import org.opendatakit.consts.IntentConsts;


### PR DESCRIPTION
ActivityCompat is deprecated in support library 27.1.0 and replaced by ActivityCompat in support-v4.
This pull request replaces usage of v13 ActivityCompat with v4 ActivityCompat.