### PR TITLE
Add JaCoCo build and run documentation to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,17 @@ If you’re new to ODK-X you can check out the documentation:
 Once you’re up and running, you can choose an issue to start working on from here: 
 - [https://github.com/odk-x/tool-suite-X/issues](https://github.com/odk-x/tool-suite-X/issues)
 
+If you're writing tests, we use JaCoCo for test coverage reporting. This is already included in [gradle-config](https://github.com/odk-x/gradle-config)
+
 Issues tagged as [good first issue](https://github.com/odk-x/tool-suite-X/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) should be a good place to start.
 
 Pull requests are welcome, though please submit them against the development branch. We prefer verbose descriptions of the change you are submitting. If you are fixing a bug please provide steps to reproduce it or a link to a an issue that provides that information. If you are submitting a new feature please provide a description of the need or a link to a forum discussion about it. 
+
+## Running test coverage
+- Clone [gradle-config](https://github.com/odk-x/gradle-config) into your local repo's parent folder
+- Build the project and ensure success.
+- Run coverage with `./gradlew createSnapshotDebugUnitTestCoverageReport`.
+- Then, follow the provided filepath to view the report.
 
 ## Links for users
 This document is aimed at helping developers and technical contributors. For information on how to get started as a user of ODK-X, see our [online documentation](https://docs.odk-x.org), or to learn more about the Open Data Kit project, visit [https://odk-x.org](https://odk-x.org).


### PR DESCRIPTION
#### This addresses issue [518](https://github.com/odk-x/tool-suite-X/issues/518).

This allows contributors to have an express information on:
- How to get JaCoCo running with the project.
- How to generate test coverage reports with JaCoCo.
- And where to view the test coverage report.